### PR TITLE
Fix user moderation for user role

### DIFF
--- a/CitadelManager/app/Http/Controllers/AppUserActivationController.php
+++ b/CitadelManager/app/Http/Controllers/AppUserActivationController.php
@@ -37,7 +37,7 @@ class AppUserActivationController extends Controller {
         if ($request->has('email')) {
             $user = User::where('email', $request->input('email'))->first();
             if ($user && $user->activations()) {
-                return $user->activations()->with('deactivation_request')->get();
+                return $user->activations()->with(['deactivation_request', 'group'])->get();
             } else {
                 return response()->json([]);
             }
@@ -46,7 +46,7 @@ class AppUserActivationController extends Controller {
                 $user_id = ($user_id != null ? $user_id : $request->has('user_id'));
                 $user = User::find($user_id);
                 if ($user && $user->activations()) {
-                    $activations = $user->activations()->with('deactivation_request')->get();
+                    $activations = $user->activations()->with(['deactivation_request', 'group'])->get();
                     return $activations;
                 } else {
                     return response()->json([]);

--- a/CitadelManager/public/js/self-moderation-entry.js
+++ b/CitadelManager/public/js/self-moderation-entry.js
@@ -10,7 +10,7 @@ Vue.component("self-moderation-list", {
                                 <li class="list-items-row" v-for="(item, index) in value">\
                                     <div class="site-text">\
                                         <editable-span :isurl="isurl" :can-edit="canEditExisting || (value[index] && value[index].isNew)" v-model="value[index]" :activations="activations" placeholder="(click here to edit)">\
-                                            <select class='form-select width-25-percent' style='display: inline-block;' v-if='!activationEdit' v-model='value[index].activation'>\
+                                            <select class='form-select width-25-percent' style='display: inline-block;' v-if='!activationEdit' v-model='value[index].activation' :disabled='!(canEditExisting || (value[index] && value[index].isNew))'>\
                                                 <option :value='globalId'>{{ globalId }}</option>\
                                                 <option v-for='(item, index) in activations' :value='activations[index].identifier'>\
                                                 {{ activations[index].device_id }}\


### PR DESCRIPTION
This disables the dropdown for choosing which device the user moderation entries apply to after it's saved for the regular user role. 