### PR TITLE
Rule selection table

### DIFF
--- a/CloudVeilManager/app/Http/Controllers/Admin/GroupCrudController.php
+++ b/CloudVeilManager/app/Http/Controllers/Admin/GroupCrudController.php
@@ -237,6 +237,19 @@ class GroupCrudController extends CrudController
                 'name' => 'notes',
                 'tab' => 'Settings',
             ],
+            // Rule Selection table (the visible control). Renders one row per FilterList with a
+            // single status control (Blacklist / Whitelist / Bypass / Ignored) and drives the three
+            // hidden relationship selects below, which the existing patchRules()/pivot sync consume.
+            [
+                'name' => 'rule_selection_table',
+                'type' => 'rule_selection_table',
+                'tab' => 'Rule Selection',
+                'filter_lists' => FilterList::orderBy('category', 'ASC')->orderBy('type', 'ASC')
+                    ->get(['id', 'namespace', 'category', 'type']),
+            ],
+            // The three status relationships stay registered so Backpack's relationship->pivot sync
+            // and patchRules() keep writing group_filter_assignments unchanged. They are hidden;
+            // the table above is their UI and drives their selected options via JS.
             [
                 'label' => 'Whitelist Rules',
                 'type' => 'relationship',
@@ -246,6 +259,7 @@ class GroupCrudController extends CrudController
                 'model' => 'App\Models\FilterList',
                 'pivot' => true,
                 'tab' => 'Rule Selection',
+                'wrapper' => ['class' => 'd-none'],
                 'options' => function ($query) {
                     return $query->orderBy('category', 'ASC')->get();
                 }
@@ -259,6 +273,7 @@ class GroupCrudController extends CrudController
                 'model' => 'App\Models\FilterList',
                 'pivot' => true,
                 'tab' => 'Rule Selection',
+                'wrapper' => ['class' => 'd-none'],
                 'options' => function ($query) {
                     return $query->orderBy('category', 'ASC')->get();
                 }
@@ -272,61 +287,10 @@ class GroupCrudController extends CrudController
                 'model' => 'App\Models\FilterList',
                 'pivot' => true,
                 'tab' => 'Rule Selection',
+                'wrapper' => ['class' => 'd-none'],
                 'options' => function ($query) {
                     return $query->orderBy('category', 'ASC')->get();
                 },
-            ],
-            [
-                'type' => 'custom_html',
-                'name' => 'my_custom_html',
-                'value' => '<script>
-                            function hideConnectedOptions(elName, otherName, label) {
-                                $("select[name=\'" + otherName + "\'] option").each(function(i, el) {
-                                    let val = $(el).val();
-                                    let selected = $(el).is(":selected");
-                                    $("select[name=\'" + elName + "\']").find("option[value=\'" + val + "\']").each(function(i, optionEl) {
-                                        let text = $(optionEl).text();
-                                        if(selected) {
-                                            if(text.indexOf(" — #") === -1) {
-                                                text = text + " — #" + label;
-                                            }
-                                        } else {
-                                            if(text.indexOf(" — #" + label) !== -1) {
-                                                text = text.replace(" — #" + label, "")
-                                            }
-                                        }
-                                        $(optionEl).text(text).prop("disabled", text.indexOf(" — #") !== -1);
-                                    });
-                                    });
-
-                                    let recreateEl = $("select[name=\'" + elName + "\']");
-                                    if (recreateEl.hasClass("select2-hidden-accessible")) {
-                                        recreateEl.select2("destroy");
-                                        bpFieldInitRelationshipSelectElement(recreateEl);
-                                    }
-                                }
-                                document.addEventListener("DOMContentLoaded", function() {
-                                    crud.field("assignedWhitelistFilters").onChange(function(field) {
-                                        debounce(function() {
-                                                hideConnectedOptions("assignedBypassFilters[]", "assignedWhitelistFilters[]", "whitelist");
-                                                hideConnectedOptions("assignedBlacklistFilters[]", "assignedWhitelistFilters[]", "whitelist");
-                                        }, 100)();
-                                    }).change();
-                                    crud.field("assignedBlacklistFilters").onChange(function(field) {
-                                        debounce(function() {
-                                            hideConnectedOptions("assignedWhitelistFilters[]", "assignedBlacklistFilters[]", "blacklist");
-                                            hideConnectedOptions("assignedBypassFilters[]", "assignedBlacklistFilters[]", "blacklist");
-                                        }, 100)();
-                                    }).change();
-                                    crud.field("assignedBypassFilters").onChange(function(field) {
-                                        debounce(function() {
-                                            hideConnectedOptions("assignedWhitelistFilters[]", "assignedBypassFilters[]", "bypasslist");
-                                            hideConnectedOptions("assignedBlacklistFilters[]", "assignedBypassFilters[]", "bypasslist");
-                                        }, 100)();
-                                    }).change();
-                                });
-                                </script>',
-                'tab' => 'Rule Selection',
             ],
             [
                 'label' => 'Application Groups Type',

--- a/CloudVeilManager/app/Http/Controllers/Admin/GroupCrudController.php
+++ b/CloudVeilManager/app/Http/Controllers/Admin/GroupCrudController.php
@@ -238,9 +238,9 @@ class GroupCrudController extends CrudController
                 'tab' => 'Settings',
             ],
             // Rule Selection table — a self-contained field. Renders one row per FilterList with a
-            // single status control (Blacklist / Whitelist / Bypass / blank) whose <select> submits
-            // as rule_status[<filter_list_id>]. store()/update() read that and sync() the single
-            // Group::assignedFilters() relation into group_filter_assignments.
+            // single status control (Blacklist / Whitelist / Bypass / blank). The table serializes all
+            // non-ignored rows into one hidden field (rule_status_json); store()/update() json_decode
+            // it and sync() the single Group::assignedFilters() relation into group_filter_assignments.
             [
                 'name' => 'rule_selection_table',
                 'type' => 'rule_selection_table',
@@ -320,7 +320,7 @@ class GroupCrudController extends CrudController
             return $this->traitStore();
         }
         // Capture the rule-selection table's input before Backpack strips unregistered inputs.
-        $ruleStatuses = (array) CRUD::getRequest()->input('rule_status', []);
+        $ruleStatuses = $this->ruleStatusesFromRequest(CRUD::getRequest());
         $result = $this->traitStore();
         $model = $this->data["entry"] ?? null;
         if ($model) {
@@ -335,7 +335,7 @@ class GroupCrudController extends CrudController
         if(!$this->validate(CRUD::getRequest(), $this->rules)) {
             return $this->traitUpdate();
         }
-        $ruleStatuses = (array) CRUD::getRequest()->input('rule_status', []);
+        $ruleStatuses = $this->ruleStatusesFromRequest(CRUD::getRequest());
         $result = $this->traitUpdate();
         $model = $this->data["entry"] ?? null;
         if ($model) {
@@ -343,6 +343,18 @@ class GroupCrudController extends CrudController
             $model->rebuildGroupData();
         }
         return $result;
+    }
+
+    /**
+     * Decode the rule-selection table's single JSON payload (rule_status_json) into a
+     * filter_list_id => status map. The table posts one hidden field for the whole grid, so the map
+     * can't be truncated by max_input_vars. A missing/invalid payload yields an empty map, which
+     * sync() interprets as "clear all assignments" — matching an all-ignored table.
+     */
+    private function ruleStatusesFromRequest($request): array
+    {
+        $decoded = json_decode((string) $request->input('rule_status_json', ''), true);
+        return is_array($decoded) ? $decoded : [];
     }
 
     /**

--- a/CloudVeilManager/app/Http/Controllers/Admin/GroupCrudController.php
+++ b/CloudVeilManager/app/Http/Controllers/Admin/GroupCrudController.php
@@ -237,60 +237,16 @@ class GroupCrudController extends CrudController
                 'name' => 'notes',
                 'tab' => 'Settings',
             ],
-            // Rule Selection table (the visible control). Renders one row per FilterList with a
-            // single status control (Blacklist / Whitelist / Bypass / Ignored) and drives the three
-            // hidden relationship selects below, which the existing patchRules()/pivot sync consume.
+            // Rule Selection table — a self-contained field. Renders one row per FilterList with a
+            // single status control (Blacklist / Whitelist / Bypass / blank) whose <select> submits
+            // as rule_status[<filter_list_id>]. store()/update() read that and sync() the single
+            // Group::assignedFilters() relation into group_filter_assignments.
             [
                 'name' => 'rule_selection_table',
                 'type' => 'rule_selection_table',
                 'tab' => 'Rule Selection',
                 'filter_lists' => FilterList::orderBy('category', 'ASC')->orderBy('type', 'ASC')
                     ->get(['id', 'namespace', 'category', 'type']),
-            ],
-            // The three status relationships stay registered so Backpack's relationship->pivot sync
-            // and patchRules() keep writing group_filter_assignments unchanged. They are hidden;
-            // the table above is their UI and drives their selected options via JS.
-            [
-                'label' => 'Whitelist Rules',
-                'type' => 'relationship',
-                'name' => 'assignedWhitelistFilters',
-                'entity' => 'assignedWhitelistFilters',
-                'attribute' => 'label',
-                'model' => 'App\Models\FilterList',
-                'pivot' => true,
-                'tab' => 'Rule Selection',
-                'wrapper' => ['class' => 'd-none'],
-                'options' => function ($query) {
-                    return $query->orderBy('category', 'ASC')->get();
-                }
-            ],
-            [
-                'label' => 'Blacklist Rules',
-                'type' => 'relationship',
-                'name' => 'assignedBlacklistFilters',
-                'entity' => 'assignedBlacklistFilters',
-                'attribute' => 'label',
-                'model' => 'App\Models\FilterList',
-                'pivot' => true,
-                'tab' => 'Rule Selection',
-                'wrapper' => ['class' => 'd-none'],
-                'options' => function ($query) {
-                    return $query->orderBy('category', 'ASC')->get();
-                }
-            ],
-            [
-                'label' => 'Bypass Rules',
-                'type' => 'relationship',
-                'name' => 'assignedBypassFilters',
-                'entity' => 'assignedBypassFilters',
-                'attribute' => 'label',
-                'model' => 'App\Models\FilterList',
-                'pivot' => true,
-                'tab' => 'Rule Selection',
-                'wrapper' => ['class' => 'd-none'],
-                'options' => function ($query) {
-                    return $query->orderBy('category', 'ASC')->get();
-                },
             ],
             [
                 'label' => 'Application Groups Type',
@@ -363,10 +319,12 @@ class GroupCrudController extends CrudController
         if(!$this->validate(CRUD::getRequest(), $this->rules)) {
             return $this->traitStore();
         }
-        $this->patchRules();
+        // Capture the rule-selection table's input before Backpack strips unregistered inputs.
+        $ruleStatuses = (array) CRUD::getRequest()->input('rule_status', []);
         $result = $this->traitStore();
         $model = $this->data["entry"] ?? null;
         if ($model) {
+            $this->syncRuleAssignments($model, $ruleStatuses);
             $model->rebuildGroupData();
         }
         return $result;
@@ -377,40 +335,35 @@ class GroupCrudController extends CrudController
         if(!$this->validate(CRUD::getRequest(), $this->rules)) {
             return $this->traitUpdate();
         }
-        $this->patchRules();
+        $ruleStatuses = (array) CRUD::getRequest()->input('rule_status', []);
         $result = $this->traitUpdate();
         $model = $this->data["entry"] ?? null;
         if ($model) {
+            $this->syncRuleAssignments($model, $ruleStatuses);
             $model->rebuildGroupData();
         }
         return $result;
     }
 
-    private function patchRules()
+    /**
+     * Persist the rule-selection table into group_filter_assignments via a single sync().
+     * $statuses maps filter_list_id => 'blacklist'|'whitelist'|'bypass'|'ignored'. Anything not one
+     * of the three active statuses is omitted, so sync() removes any existing assignment row for it.
+     */
+    private function syncRuleAssignments(Group $group, array $statuses): void
     {
-        $this->patchRule("assignedBlacklistFilters", 1, 0, 0);
-        $this->patchRule("assignedWhitelistFilters", 0, 1, 0);
-        $this->patchRule("assignedBypassFilters", 0, 0, 1);
-    }
-
-    private function patchRule($key, $asBlacklist, $asWhitelist, $asBypass)
-    {
-        $request = CRUD::getRequest();
-        $listFilters = $request->input($key);
-        if (!empty($listFilters)) {
-            $newData = [];
-            foreach ($listFilters as $listFilterId) {
-                $newData[] = [
-                    $key => $listFilterId,
-                    "as_blacklist" => $asBlacklist,
-                    "as_whitelist" => $asWhitelist,
-                    "as_bypass" => $asBypass
-                ];
+        $sync = [];
+        foreach ($statuses as $filterListId => $status) {
+            if (!in_array($status, ['blacklist', 'whitelist', 'bypass'], true)) {
+                continue;
             }
-
-            $request->request->set($key, $newData);
-            CRUD::setRequest($request);
+            $sync[(int) $filterListId] = [
+                'as_blacklist' => $status === 'blacklist' ? 1 : 0,
+                'as_whitelist' => $status === 'whitelist' ? 1 : 0,
+                'as_bypass'    => $status === 'bypass' ? 1 : 0,
+            ];
         }
+        $group->assignedFilters()->sync($sync);
     }
 
     public function destroy($id)

--- a/CloudVeilManager/app/Models/Group.php
+++ b/CloudVeilManager/app/Models/Group.php
@@ -89,6 +89,22 @@ class Group extends Model
             ->wherePivot("as_bypass", "=", 1);
     }
 
+    /**
+     * All filter-list assignments for this group in a single relation, carrying the status flags
+     * as pivot data. This is the encompassing relation the rule-selection admin field reads and
+     * writes (via sync()) — it replaces the three per-status belongsToMany relations on the write
+     * side. The three per-status relations remain only for legacy/read convenience.
+     */
+    public function assignedFilters()
+    {
+        return $this->belongsToMany('App\Models\FilterList',
+            'group_filter_assignments',
+            'group_id',
+            'filter_list_id')
+            ->withPivot('as_blacklist', 'as_whitelist', 'as_bypass')
+            ->withTimestamps();
+    }
+
     public function assignedApplicationRules()
     {
         return $this->belongsToMany('App\Models\AppGroup',

--- a/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
+++ b/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
@@ -55,14 +55,11 @@
                     @endphp
                     <tr data-list-id="{{ $list->id }}" data-status="ignored">
                         <td>{{ $list->category }}</td>
-                        <td>
-                            <span class="badge {{ $isTrigger ? 'bg-red' : 'bg-green' }}">
-                                {{ $isTrigger ? 'Trigger' : 'Filter' }}
-                            </span>
-                        </td>
-                        <td>
+                        <td>{{ $isTrigger ? 'Trigger' : 'Filter' }}</td>
+                        {{-- data-order drives the (dynamic) sort of the status column; JS keeps it in sync --}}
+                        <td class="rule-status-cell" data-order="9">
                             <select class="form-select form-select-sm rule-status-select" data-list-id="{{ $list->id }}">
-                                <option value="ignored">Ignored</option>
+                                <option value="ignored"></option>
                                 <option value="blacklist">Blacklist</option>
                                 <option value="whitelist">Whitelist</option>
                                 <option value="bypass">Bypass</option>
@@ -83,6 +80,18 @@
 
 @push('crud_fields_styles')
     @basset('https://cdn.datatables.net/1.13.1/css/dataTables.bootstrap5.min.css')
+    <style>
+        /* Borderless, transparent status control — colored text only, keyed off the row's status
+           (tr[data-status], kept in sync by JS). Tabler's .form-select rules tie on specificity and
+           load after ours, so force with !important. */
+        select.rule-status-select { border: 0 !important; box-shadow: none !important; background-color: transparent !important; outline: none !important; }
+
+        table.rule-selection-datatable tbody td:first-child { font-weight: 600; }
+
+        tr[data-status="blacklist"] .rule-status-select { color: #d63939; font-weight: 600; }
+        tr[data-status="whitelist"] .rule-status-select { color: #1f9d57; font-weight: 600; }
+        tr[data-status="bypass"]    .rule-status-select { color: #d9a406; font-weight: 600; }
+    </style>
 @endpush
 
 @push('crud_fields_scripts')
@@ -147,14 +156,24 @@
                     });
                 }
 
+                // Sort rank for the status column (blank/ignored sorts last).
+                var STATUS_RANK = { blacklist: 0, whitelist: 1, bypass: 2, ignored: 9 };
+
+                // Sync a row's visible state (row data-status, the control's value + color class,
+                // and the status cell's data-order used for sorting). DOM-only; safe pre-DataTables.
+                function applyRowVisual($tr, status) {
+                    $tr.attr('data-status', status); // drives the color CSS
+                    $tr.find('.rule-status-select').val(status);
+                    var rank = STATUS_RANK[status];
+                    $tr.find('.rule-status-cell').attr('data-order', rank == null ? 9 : rank);
+                }
+
                 // Initialize each row's control + data-status from the hidden selects.
                 var initial = readInitialStatuses();
                 $table.find('tbody tr').each(function () {
                     var $tr = $(this);
                     var listId = String($tr.data('list-id'));
-                    var status = initial[listId] || 'ignored';
-                    $tr.attr('data-status', status);
-                    $tr.find('.rule-status-select').val(status);
+                    applyRowVisual($tr, initial[listId] || 'ignored');
                 });
 
                 // DataTables: search Category column only; keep pagination.
@@ -166,8 +185,8 @@
                     ordering: true,
                     order: [[0, 'asc']],
                     columnDefs: [
+                        // Type + Status columns aren't full-text searchable; Status sorts by data-order.
                         { targets: [1, 2], searchable: false },
-                        { targets: [2], orderable: false },
                     ],
                     // no default search box (we use our own); 'l' = length menu, 'i' = info, 'p' = pagination
                     dom: 'rltip',
@@ -195,16 +214,17 @@
                     dt.draw();
                 });
 
-                // Row status change -> update hidden selects, row state, and re-apply the filter.
+                // Row status change -> update hidden selects, row visuals, status-sort key, and
+                // re-apply search/filter/sort (draw(false) preserves the current page length).
                 $table.on('change', '.rule-status-select', function () {
                     var $select = $(this);
+                    var $tr = $select.closest('tr');
                     var listId = $select.data('list-id');
                     var status = $select.val();
-                    $select.closest('tr').attr('data-status', status);
+                    applyRowVisual($tr, status);
                     applyStatus(listId, status);
-                    if (activeStatusFilter) {
-                        dt.draw();
-                    }
+                    dt.cell($tr.find('.rule-status-cell')[0]).invalidate();
+                    dt.draw(false);
                 });
             }
 

--- a/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
+++ b/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
@@ -1,0 +1,223 @@
+{{-- Rule selection table field --}}
+{{--
+    Renders one row per FilterList with a single status control
+    (Blacklist / Whitelist / Bypass / Ignored). The control drives the three hidden
+    `relationship` select2 fields (assignedBlacklistFilters / assignedWhitelistFilters /
+    assignedBypassFilters) rendered elsewhere on this tab, which the existing
+    GroupCrudController::patchRules() + Backpack pivot sync consume unchanged.
+
+    Search filters the Category column only. A single-select status dropdown filters rows
+    by their current status. Persistence happens only on the group form Save.
+--}}
+@php
+    $filterLists = $field['filter_lists'] ?? collect();
+    $tableId = 'rule_selection_table_' . \Illuminate\Support\Str::random(6);
+@endphp
+
+@include('crud::fields.inc.wrapper_start')
+
+    <label>Rule Selection</label>
+
+    <div class="rule-selection-field" data-init="0"
+         data-table="#{{ $tableId }}"
+         data-blacklist-select="assignedBlacklistFilters[]"
+         data-whitelist-select="assignedWhitelistFilters[]"
+         data-bypass-select="assignedBypassFilters[]">
+
+        <div class="row mb-2">
+            <div class="col-md-4 mb-2">
+                <input type="text" class="form-control rule-search"
+                       placeholder="Search category…" autocomplete="off">
+            </div>
+            <div class="col-md-3 mb-2">
+                <select class="form-select rule-status-filter">
+                    <option value="">All statuses</option>
+                    <option value="blacklist">Blacklists</option>
+                    <option value="whitelist">Whitelists</option>
+                    <option value="bypass">Bypassed</option>
+                    <option value="ignored">Ignored</option>
+                </select>
+            </div>
+        </div>
+
+        <table id="{{ $tableId }}" class="table table-sm table-striped rule-selection-datatable" style="width:100%">
+            <thead>
+                <tr>
+                    <th>Category</th>
+                    <th>Type</th>
+                    <th style="width: 180px;">Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($filterLists as $list)
+                    @php
+                        $isTrigger = $list->type === 'Triggers';
+                    @endphp
+                    <tr data-list-id="{{ $list->id }}" data-status="ignored">
+                        <td>{{ $list->category }}</td>
+                        <td>
+                            <span class="badge {{ $isTrigger ? 'bg-red' : 'bg-green' }}">
+                                {{ $isTrigger ? 'Trigger' : 'Filter' }}
+                            </span>
+                        </td>
+                        <td>
+                            <select class="form-select form-select-sm rule-status-select" data-list-id="{{ $list->id }}">
+                                <option value="ignored">Ignored</option>
+                                <option value="blacklist">Blacklist</option>
+                                <option value="whitelist">Whitelist</option>
+                                <option value="bypass">Bypass</option>
+                            </select>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    {{-- HINT --}}
+    @if (isset($field['hint']))
+        <p class="help-block">{!! $field['hint'] !!}</p>
+    @endif
+
+@include('crud::fields.inc.wrapper_end')
+
+@push('crud_fields_styles')
+    @basset('https://cdn.datatables.net/1.13.1/css/dataTables.bootstrap5.min.css')
+@endpush
+
+@push('crud_fields_scripts')
+    @basset('https://cdn.datatables.net/1.13.1/js/jquery.dataTables.min.js')
+    @basset('https://cdn.datatables.net/1.13.1/js/dataTables.bootstrap5.min.js')
+
+    @bassetBlock('cloudveil/fields/rule-selection-table.js')
+    <script>
+        (function () {
+            function initRuleSelectionField(root) {
+                if (root.getAttribute('data-init') === '1') {
+                    return;
+                }
+                root.setAttribute('data-init', '1');
+
+                var $ = window.jQuery;
+                var $root = $(root);
+                var tableSelector = root.getAttribute('data-table');
+                var $table = $(tableSelector);
+
+                // The three hidden relationship <select multiple> that actually get submitted.
+                var statusSelects = {
+                    blacklist: document.querySelector('select[name="' + root.getAttribute('data-blacklist-select') + '"]'),
+                    whitelist: document.querySelector('select[name="' + root.getAttribute('data-whitelist-select') + '"]'),
+                    bypass: document.querySelector('select[name="' + root.getAttribute('data-bypass-select') + '"]'),
+                };
+
+                // Read the current selection out of the hidden selects (honors old() on validation
+                // errors and prefilled values on edit). Returns { listId: status }.
+                function readInitialStatuses() {
+                    var map = {};
+                    Object.keys(statusSelects).forEach(function (status) {
+                        var sel = statusSelects[status];
+                        if (!sel) return;
+                        Array.prototype.forEach.call(sel.options, function (opt) {
+                            if (opt.selected) {
+                                map[String(opt.value)] = status;
+                            }
+                        });
+                    });
+                    return map;
+                }
+
+                // Drive a hidden select2 relationship select so listId is selected there iff
+                // `shouldSelect`, then notify select2/Backpack via change.
+                function setHiddenSelectValue(status, listId, shouldSelect) {
+                    var sel = statusSelects[status];
+                    if (!sel) return;
+                    var id = String(listId);
+                    var current = $(sel).val() || [];
+                    current = current.map(String).filter(function (v) { return v !== id; });
+                    if (shouldSelect) {
+                        current.push(id);
+                    }
+                    $(sel).val(current).trigger('change');
+                }
+
+                // Apply a status to one list across all three hidden selects (mutually exclusive).
+                function applyStatus(listId, status) {
+                    ['blacklist', 'whitelist', 'bypass'].forEach(function (s) {
+                        setHiddenSelectValue(s, listId, s === status);
+                    });
+                }
+
+                // Initialize each row's control + data-status from the hidden selects.
+                var initial = readInitialStatuses();
+                $table.find('tbody tr').each(function () {
+                    var $tr = $(this);
+                    var listId = String($tr.data('list-id'));
+                    var status = initial[listId] || 'ignored';
+                    $tr.attr('data-status', status);
+                    $tr.find('.rule-status-select').val(status);
+                });
+
+                // DataTables: search Category column only; keep pagination.
+                var dt = $table.DataTable({
+                    paging: true,
+                    pageLength: 10,
+                    lengthChange: true,
+                    lengthMenu: [[10, 25, 50, 100, -1], ['10', '25', '50', '100', 'All']],
+                    ordering: true,
+                    order: [[0, 'asc']],
+                    columnDefs: [
+                        { targets: [1, 2], searchable: false },
+                        { targets: [2], orderable: false },
+                    ],
+                    // no default search box (we use our own); 'l' = length menu, 'i' = info, 'p' = pagination
+                    dom: 'rltip',
+                });
+
+                // Our search box -> filter Category column (index 0) only.
+                $root.find('.rule-search').on('keyup change', function () {
+                    dt.column(0).search(this.value).draw();
+                });
+
+                // Single-select status filter via a DataTables custom search predicate.
+                var activeStatusFilter = '';
+                $.fn.dataTable.ext.search.push(function (settings, data, dataIndex) {
+                    if (settings.nTable !== $table[0]) {
+                        return true; // don't affect other tables
+                    }
+                    if (!activeStatusFilter) {
+                        return true;
+                    }
+                    var row = settings.aoData[dataIndex].nTr;
+                    return row.getAttribute('data-status') === activeStatusFilter;
+                });
+                $root.find('.rule-status-filter').on('change', function () {
+                    activeStatusFilter = this.value;
+                    dt.draw();
+                });
+
+                // Row status change -> update hidden selects, row state, and re-apply the filter.
+                $table.on('change', '.rule-status-select', function () {
+                    var $select = $(this);
+                    var listId = $select.data('list-id');
+                    var status = $select.val();
+                    $select.closest('tr').attr('data-status', status);
+                    applyStatus(listId, status);
+                    if (activeStatusFilter) {
+                        dt.draw();
+                    }
+                });
+            }
+
+            function boot() {
+                document.querySelectorAll('.rule-selection-field').forEach(initRuleSelectionField);
+            }
+
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', boot);
+            } else {
+                boot();
+            }
+        })();
+    </script>
+    @endBassetBlock
+@endpush

--- a/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
+++ b/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
@@ -1,10 +1,12 @@
 {{-- Rule selection table field --}}
 {{--
     Self-contained field. Renders one row per FilterList with a single status control
-    (Blacklist / Whitelist / Bypass / blank) whose <select> submits directly as
-    rule_status[<filter_list_id>]. GroupCrudController::store()/update() read that map and
-    sync() the single Group::assignedFilters() relation into group_filter_assignments — no hidden
-    relationship fields, no patchRules().
+    (Blacklist / Whitelist / Bypass / blank). On submit, JS serializes every non-ignored row into a
+    single hidden input (rule_status_json) — one form variable regardless of list count, so the POST
+    can't be truncated by PHP's max_input_vars, and DataTables detaching off-page rows can't drop
+    inputs (we read all rows via the DataTables API, not the DOM). GroupCrudController::store()/update()
+    json_decode that map and sync() the single Group::assignedFilters() relation into
+    group_filter_assignments — no per-row inputs, no hidden relationship fields, no patchRules().
 
     Search filters the Category column only. A single-select status dropdown filters rows by their
     current status. The status column sorts by status. Persistence happens only on group form Save.
@@ -17,9 +19,12 @@
     $rankMap = ['blacklist' => 0, 'whitelist' => 1, 'bypass' => 2, 'ignored' => 9];
 
     // Prefill: old() input wins (validation error re-render), else the group's saved assignments.
-    $oldStatuses = old('rule_status');
+    // old() now carries the JSON map (rule_status_json); an empty map is still a valid "all ignored"
+    // submission, so key off presence of the field, not truthiness of the decoded array.
+    $hasOld = old('rule_status_json') !== null;
+    $oldStatuses = $hasOld ? (json_decode(old('rule_status_json'), true) ?: []) : [];
     $currentStatuses = [];
-    if (!$oldStatuses && isset($entry) && $entry) {
+    if (!$hasOld && isset($entry) && $entry) {
         foreach ($entry->assignedFilters as $assigned) {
             $p = $assigned->pivot;
             $currentStatuses[$assigned->id] = $p->as_blacklist ? 'blacklist'
@@ -71,8 +76,8 @@
                         <td>{{ $isTrigger ? 'Trigger' : 'Filter' }}</td>
                         {{-- data-order drives the (dynamic) sort of the status column; JS keeps it in sync --}}
                         <td class="rule-status-cell" data-order="{{ $rank }}">
-                            <select class="form-select form-select-sm rule-status-select"
-                                    name="rule_status[{{ $list->id }}]">
+                            {{-- No name: values are gathered into rule_status_json on submit (below). --}}
+                            <select class="form-select form-select-sm rule-status-select">
                                 <option value="ignored" @selected($status === 'ignored')></option>
                                 <option value="blacklist" @selected($status === 'blacklist')>Blacklist</option>
                                 <option value="whitelist" @selected($status === 'whitelist')>Whitelist</option>
@@ -83,6 +88,11 @@
                 @endforeach
             </tbody>
         </table>
+
+        {{-- Single form variable for the whole table. JS fills it on submit; the value here keeps a
+             valid payload if JS never runs (e.g. save before boot) and preserves old() on re-render. --}}
+        <input type="hidden" name="rule_status_json" class="rule-status-json"
+               value="{{ $hasOld ? old('rule_status_json') : json_encode(array_filter($currentStatuses, fn ($s) => $s !== 'ignored')) }}">
     </div>
 
     {{-- HINT --}}
@@ -124,6 +134,7 @@
                 var $ = window.jQuery;
                 var $root = $(root);
                 var $table = $(root.getAttribute('data-table'));
+                var $hidden = $root.find('.rule-status-json');
 
                 // Sort rank for the status column (blank/ignored sorts last).
                 var STATUS_RANK = { blacklist: 0, whitelist: 1, bypass: 2, ignored: 9 };
@@ -166,8 +177,27 @@
                     dt.draw();
                 });
 
-                // Row status change -> the <select> is the submitted input, so we only keep the row's
-                // data-status (drives color + filter) and the status-sort key in sync, then redraw.
+                // Serialize every non-ignored row into the single hidden input. Reads via the
+                // DataTables API (dt.rows().nodes()) rather than the DOM, so rows detached by
+                // pagination are still included — that's the whole point of the JSON payload.
+                function serialize() {
+                    var map = {};
+                    dt.rows().nodes().to$().find('.rule-status-select').each(function () {
+                        var v = this.value;
+                        if (v && v !== 'ignored') {
+                            map[this.closest('tr').getAttribute('data-list-id')] = v;
+                        }
+                    });
+                    $hidden.val(JSON.stringify(map));
+                }
+
+                // Keep the payload current on every change, and rebuild once more at submit time as the
+                // authoritative capture (covers any row not touched since boot).
+                serialize();
+                $root.closest('form').on('submit', serialize);
+
+                // Row status change -> keep the row's data-status (drives color + filter) and the
+                // status-sort key in sync, refresh the payload, then redraw.
                 $table.on('change', '.rule-status-select', function () {
                     var $select = $(this);
                     var $tr = $select.closest('tr');
@@ -177,6 +207,7 @@
                     $tr.find('.rule-status-cell').attr('data-order', rank == null ? 9 : rank);
                     dt.cell($tr.find('.rule-status-cell')[0]).invalidate();
                     dt.draw(false);
+                    serialize();
                 });
             }
 

--- a/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
+++ b/CloudVeilManager/resources/views/vendor/backpack/crud/fields/rule_selection_table.blade.php
@@ -1,28 +1,39 @@
 {{-- Rule selection table field --}}
 {{--
-    Renders one row per FilterList with a single status control
-    (Blacklist / Whitelist / Bypass / Ignored). The control drives the three hidden
-    `relationship` select2 fields (assignedBlacklistFilters / assignedWhitelistFilters /
-    assignedBypassFilters) rendered elsewhere on this tab, which the existing
-    GroupCrudController::patchRules() + Backpack pivot sync consume unchanged.
+    Self-contained field. Renders one row per FilterList with a single status control
+    (Blacklist / Whitelist / Bypass / blank) whose <select> submits directly as
+    rule_status[<filter_list_id>]. GroupCrudController::store()/update() read that map and
+    sync() the single Group::assignedFilters() relation into group_filter_assignments — no hidden
+    relationship fields, no patchRules().
 
-    Search filters the Category column only. A single-select status dropdown filters rows
-    by their current status. Persistence happens only on the group form Save.
+    Search filters the Category column only. A single-select status dropdown filters rows by their
+    current status. The status column sorts by status. Persistence happens only on group form Save.
 --}}
 @php
     $filterLists = $field['filter_lists'] ?? collect();
     $tableId = 'rule_selection_table_' . \Illuminate\Support\Str::random(6);
+
+    // Sort rank for the status column (blank/ignored sorts last).
+    $rankMap = ['blacklist' => 0, 'whitelist' => 1, 'bypass' => 2, 'ignored' => 9];
+
+    // Prefill: old() input wins (validation error re-render), else the group's saved assignments.
+    $oldStatuses = old('rule_status');
+    $currentStatuses = [];
+    if (!$oldStatuses && isset($entry) && $entry) {
+        foreach ($entry->assignedFilters as $assigned) {
+            $p = $assigned->pivot;
+            $currentStatuses[$assigned->id] = $p->as_blacklist ? 'blacklist'
+                : ($p->as_whitelist ? 'whitelist'
+                : ($p->as_bypass ? 'bypass' : 'ignored'));
+        }
+    }
 @endphp
 
 @include('crud::fields.inc.wrapper_start')
 
     <label>Rule Selection</label>
 
-    <div class="rule-selection-field" data-init="0"
-         data-table="#{{ $tableId }}"
-         data-blacklist-select="assignedBlacklistFilters[]"
-         data-whitelist-select="assignedWhitelistFilters[]"
-         data-bypass-select="assignedBypassFilters[]">
+    <div class="rule-selection-field" data-init="0" data-table="#{{ $tableId }}">
 
         <div class="row mb-2">
             <div class="col-md-4 mb-2">
@@ -52,17 +63,20 @@
                 @foreach ($filterLists as $list)
                     @php
                         $isTrigger = $list->type === 'Triggers';
+                        $status = $oldStatuses[$list->id] ?? $currentStatuses[$list->id] ?? 'ignored';
+                        $rank = $rankMap[$status] ?? 9;
                     @endphp
-                    <tr data-list-id="{{ $list->id }}" data-status="ignored">
+                    <tr data-list-id="{{ $list->id }}" data-status="{{ $status }}">
                         <td>{{ $list->category }}</td>
                         <td>{{ $isTrigger ? 'Trigger' : 'Filter' }}</td>
                         {{-- data-order drives the (dynamic) sort of the status column; JS keeps it in sync --}}
-                        <td class="rule-status-cell" data-order="9">
-                            <select class="form-select form-select-sm rule-status-select" data-list-id="{{ $list->id }}">
-                                <option value="ignored"></option>
-                                <option value="blacklist">Blacklist</option>
-                                <option value="whitelist">Whitelist</option>
-                                <option value="bypass">Bypass</option>
+                        <td class="rule-status-cell" data-order="{{ $rank }}">
+                            <select class="form-select form-select-sm rule-status-select"
+                                    name="rule_status[{{ $list->id }}]">
+                                <option value="ignored" @selected($status === 'ignored')></option>
+                                <option value="blacklist" @selected($status === 'blacklist')>Blacklist</option>
+                                <option value="whitelist" @selected($status === 'whitelist')>Whitelist</option>
+                                <option value="bypass" @selected($status === 'bypass')>Bypass</option>
                             </select>
                         </td>
                     </tr>
@@ -109,74 +123,12 @@
 
                 var $ = window.jQuery;
                 var $root = $(root);
-                var tableSelector = root.getAttribute('data-table');
-                var $table = $(tableSelector);
-
-                // The three hidden relationship <select multiple> that actually get submitted.
-                var statusSelects = {
-                    blacklist: document.querySelector('select[name="' + root.getAttribute('data-blacklist-select') + '"]'),
-                    whitelist: document.querySelector('select[name="' + root.getAttribute('data-whitelist-select') + '"]'),
-                    bypass: document.querySelector('select[name="' + root.getAttribute('data-bypass-select') + '"]'),
-                };
-
-                // Read the current selection out of the hidden selects (honors old() on validation
-                // errors and prefilled values on edit). Returns { listId: status }.
-                function readInitialStatuses() {
-                    var map = {};
-                    Object.keys(statusSelects).forEach(function (status) {
-                        var sel = statusSelects[status];
-                        if (!sel) return;
-                        Array.prototype.forEach.call(sel.options, function (opt) {
-                            if (opt.selected) {
-                                map[String(opt.value)] = status;
-                            }
-                        });
-                    });
-                    return map;
-                }
-
-                // Drive a hidden select2 relationship select so listId is selected there iff
-                // `shouldSelect`, then notify select2/Backpack via change.
-                function setHiddenSelectValue(status, listId, shouldSelect) {
-                    var sel = statusSelects[status];
-                    if (!sel) return;
-                    var id = String(listId);
-                    var current = $(sel).val() || [];
-                    current = current.map(String).filter(function (v) { return v !== id; });
-                    if (shouldSelect) {
-                        current.push(id);
-                    }
-                    $(sel).val(current).trigger('change');
-                }
-
-                // Apply a status to one list across all three hidden selects (mutually exclusive).
-                function applyStatus(listId, status) {
-                    ['blacklist', 'whitelist', 'bypass'].forEach(function (s) {
-                        setHiddenSelectValue(s, listId, s === status);
-                    });
-                }
+                var $table = $(root.getAttribute('data-table'));
 
                 // Sort rank for the status column (blank/ignored sorts last).
                 var STATUS_RANK = { blacklist: 0, whitelist: 1, bypass: 2, ignored: 9 };
 
-                // Sync a row's visible state (row data-status, the control's value + color class,
-                // and the status cell's data-order used for sorting). DOM-only; safe pre-DataTables.
-                function applyRowVisual($tr, status) {
-                    $tr.attr('data-status', status); // drives the color CSS
-                    $tr.find('.rule-status-select').val(status);
-                    var rank = STATUS_RANK[status];
-                    $tr.find('.rule-status-cell').attr('data-order', rank == null ? 9 : rank);
-                }
-
-                // Initialize each row's control + data-status from the hidden selects.
-                var initial = readInitialStatuses();
-                $table.find('tbody tr').each(function () {
-                    var $tr = $(this);
-                    var listId = String($tr.data('list-id'));
-                    applyRowVisual($tr, initial[listId] || 'ignored');
-                });
-
-                // DataTables: search Category column only; keep pagination.
+                // DataTables: search Category column only; status column sorts by data-order.
                 var dt = $table.DataTable({
                     paging: true,
                     pageLength: 10,
@@ -214,15 +166,15 @@
                     dt.draw();
                 });
 
-                // Row status change -> update hidden selects, row visuals, status-sort key, and
-                // re-apply search/filter/sort (draw(false) preserves the current page length).
+                // Row status change -> the <select> is the submitted input, so we only keep the row's
+                // data-status (drives color + filter) and the status-sort key in sync, then redraw.
                 $table.on('change', '.rule-status-select', function () {
                     var $select = $(this);
                     var $tr = $select.closest('tr');
-                    var listId = $select.data('list-id');
                     var status = $select.val();
-                    applyRowVisual($tr, status);
-                    applyStatus(listId, status);
+                    var rank = STATUS_RANK[status];
+                    $tr.attr('data-status', status);
+                    $tr.find('.rule-status-cell').attr('data-order', rank == null ? 9 : rank);
                     dt.cell($tr.find('.rule-status-cell')[0]).invalidate();
                     dt.draw(false);
                 });


### PR DESCRIPTION
This changes the rule selection from dropdown multiselects to a searchable table. This should make it easier to find the categories update them. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how group filter-list assignments are saved and synced, which directly affects compiled group filtering config; behavior should be equivalent but warrants careful QA on create/update and ignored/cleared rules.
> 
> **Overview**
> Replaces the **Rule Selection** tab’s three Backpack relationship multiselects (whitelist, blacklist, bypass) and the inline jQuery that blocked the same filter list across lists with a single custom **`rule_selection_table`** field.
> 
> The new UI is a **DataTables** table (category search, status filter, per-row status dropdown) that posts `rule_status[<filter_list_id>]` as blacklist, whitelist, bypass, or ignored/blank. **`GroupCrudController::store()` / `update()`** read that map before Backpack strips unregistered fields, then **`syncRuleAssignments()`** writes **`group_filter_assignments`** through a new **`Group::assignedFilters()`** relation instead of **`patchRules()`** on three separate pivot fields.
> 
> Legacy per-status **`assignedWhitelistFilters`** / **`assignedBlacklistFilters`** / **`assignedBypassFilters`** relations are unchanged for read paths; group data still rebuilds after save via **`rebuildGroupData()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d6b3794201b1f1a220c95e76dfd442b776650aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->