### PR TITLE
Harden CloudVeilManager security (auth, redirects, path traversal)

### DIFF
--- a/CloudVeilManager/app/Exceptions/Handler.php
+++ b/CloudVeilManager/app/Exceptions/Handler.php
@@ -54,9 +54,9 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
-        // 403 errors should be redirected to login.
+        // 403 errors should be redirected to login with a same-origin relative path only.
         if ($exception instanceof HttpException && $exception->getStatusCode() == 403) {
-            return redirect('/login?redirect=' . urlencode($request->fullUrl()));
+            return redirect('/login?redirect=' . urlencode($request->getRequestUri()));
         }
         // XXX TODO - We don't want the ugly laravel exception pages.
         // In the parent, I think it's just the $exception->getResponse() that

--- a/CloudVeilManager/app/Http/Controllers/AppUserActivationController.php
+++ b/CloudVeilManager/app/Http/Controllers/AppUserActivationController.php
@@ -12,14 +12,53 @@ namespace App\Http\Controllers;
 use App\Events\ActivationBypassDenied;
 use App\Events\ActivationBypassGranted;
 use App\Models\AppUserActivation;
+use App\Models\SystemPlatform;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 
 class AppUserActivationController extends Controller {
 
     public function __construct() {
 
+    }
+
+    /**
+     * Update OS/platform metadata for an activation bound by identifier + device_id.
+     */
+    public function updateVersion(Request $request) {
+        if(!$request->has("acid") || !$request->has("os") || !$request->has("os_version")) {
+            return response('', 200);
+        }
+
+        if (!$request->has('identifier') || !$request->has('device_id')) {
+            return response('Unauthorized', 401);
+        }
+
+        // acid must match the device-bound identifier from check.device_id.
+        if ($request->input('identifier') !== $request->input('acid')) {
+            return response('Unauthorized', 401);
+        }
+
+        $osName = $request->input("os");
+        $osVersion = $request->input("os_version");
+
+        $activation = AppUserActivation::where('identifier', $request->input("acid"))
+            ->where('device_id', $request->input('device_id'))
+            ->first();
+
+        if (!$activation) {
+            return response('Activation does not exist.', 404);
+        }
+
+        if(in_array($osName, SystemPlatform::PLATFORM_SUPPORTED)) {
+            $activation->platform_name = $osName;
+        }
+        $activation->os_version = is_string($osVersion) ? substr($osVersion, 0, 255) : '';
+        $activation->save();
+
+        return response('', 200);
     }
 
     /**

--- a/CloudVeilManager/app/Http/Controllers/Auth/LoginController.php
+++ b/CloudVeilManager/app/Http/Controllers/Auth/LoginController.php
@@ -75,7 +75,7 @@ class LoginController extends LoginControllerBase
     }
 
     public function login(Request $request) {
-        $redirect = $request->input('redirect');
+        $redirect = safe_redirect_path($request->input('redirect'));
 
         if($redirect != null) {
             $this->innerRedirectTo = $redirect;
@@ -94,7 +94,7 @@ class LoginController extends LoginControllerBase
         $authUser = $this->findOrCreateUser($user, $provider);
         Auth::login($authUser, true);
 
-        $redirect = $request->input('redirect');
+        $redirect = safe_redirect_path($request->input('redirect'));
 
         if($redirect != null) {
             $this->innerRedirectTo = $redirect;
@@ -115,6 +115,11 @@ class LoginController extends LoginControllerBase
         $authUser = User::where('email', $user->email)->first();
 
         if($authUser) {
+            // Do not silently link password-backed accounts to SSO (account takeover risk).
+            if (!empty($authUser->password)) {
+                abort(403, 'An account with this email already exists. Please log in with your password first.');
+            }
+
             $authUser->provider = $provider;
             $authUser->provider_id = $user->id;
             $authUser->save();

--- a/CloudVeilManager/app/Http/Controllers/UpdateController.php
+++ b/CloudVeilManager/app/Http/Controllers/UpdateController.php
@@ -173,7 +173,23 @@ class UpdateController extends Controller
         }
         Log::info("Update download from " . $request->ip() . " id: " . $activationId);
         AppUserActivation::setLastUpdateRequestTime($request->ip(), $activationId);
-        $file = public_path() . "/releases/" . $fileName;
+
+        // Prevent path traversal: only allow a basename under public/releases.
+        $safeName = basename((string) $fileName);
+        if ($safeName === '' || $safeName === '.' || $safeName === '..' || $safeName !== $fileName) {
+            abort(404);
+        }
+
+        $releasesDir = realpath(public_path('releases'));
+        if ($releasesDir === false) {
+            abort(404);
+        }
+
+        $file = realpath($releasesDir . DIRECTORY_SEPARATOR . $safeName);
+        if ($file === false || !str_starts_with($file, $releasesDir . DIRECTORY_SEPARATOR) || !is_file($file)) {
+            abort(404);
+        }
+
         return response()->download($file);
     }
 

--- a/CloudVeilManager/app/Http/Controllers/UserController.php
+++ b/CloudVeilManager/app/Http/Controllers/UserController.php
@@ -162,9 +162,9 @@ class UserController extends Controller
             ], 400);
         }
 
-        if (!$request->has('new_password') || $request->input('new_password') == null || strlen($request->input('new_password')) < 4) {
+        if (!$request->has('new_password') || $request->input('new_password') == null || strlen($request->input('new_password')) < 8) {
             return response()->json([
-                'error' => 'The new password you entered should be filled out and longer than 3 characters'
+                'error' => 'The new password you entered should be filled out and at least 8 characters'
             ], 400);
         }
 
@@ -558,8 +558,9 @@ class UserController extends Controller
     }
 
     /**
-     * Handles when the application has lost it's credentials.  If the activation exists
-     * it returns a token and the users email address.
+     * Handles when the application has lost its credentials. Requires HTTP basic
+     * auth (same as gettoken). Issues a token only when the activation belongs
+     * to the authenticated user.
      * @param Request $request
      */
     public function retrieveUserToken(Request $request)
@@ -569,39 +570,43 @@ class UserController extends Controller
             'device_id' => 'required',
         ]);
 
-        if (!$validator->fails()) {
-            $activation = AppUserActivation::where('identifier', $request->input('identifier'))
+        if ($validator->fails()) {
+            return response($validator->errors(), 401);
+        }
+
+        $authUser = \Auth::user();
+        if (!$authUser) {
+            return response('Unauthorized', 401);
+        }
+
+        $activation = AppUserActivation::where('identifier', $request->input('identifier'))
+            ->where('device_id', $request->input('device_id'))
+            ->where('user_id', $authUser->id)
+            ->first();
+        if(!$activation) {
+            $activation = AppUserActivation::withTrashed()
+                ->where('identifier', $request->input('identifier'))
                 ->where('device_id', $request->input('device_id'))
+                ->where('user_id', $authUser->id)
+                ->orderBy("last_sync_time", "DESC")
                 ->first();
-            if(!$activation) {
-                $activation = AppUserActivation::withTrashed()
-                    ->where('identifier', $request->input('identifier'))
-                    ->where('device_id', $request->input('device_id'))
-                    ->orderBy("last_sync_time", "DESC")
-                    ->first();
-                if($activation) {
-                    $activation->restore();
-                }
-            }
-            if ($activation) {
-                // Lookup the user this activation belongs to.
-                $user = User::where('id', $activation->user_id)->first();
-                if ($user->isactive) {
-                    // Creating a token without scopes...
-                    $token = $user->createToken('Token Name')->accessToken;
-                    return response([
-                        'authToken' => $token,
-                        'userEmail' => $user->email,
-                    ], 200);
-                } else {
-                    // User is not active.km
-                    return response('User is not active', 401);
-                }
-            } else {
-                return response('Activation does not exist.', 401);
+            if($activation) {
+                $activation->restore();
             }
         }
-        return response($validator->errors(), 401);
+        if ($activation) {
+            if ($authUser->isactive) {
+                $token = $authUser->createToken('Token Name')->accessToken;
+                return response([
+                    'authToken' => $token,
+                    'userEmail' => $authUser->email,
+                ], 200);
+            } else {
+                return response('User is not active', 401);
+            }
+        } else {
+            return response('Activation does not exist.', 401);
+        }
     }
 
     /**
@@ -677,16 +682,22 @@ class UserController extends Controller
 
     /**
      * Used by our debugging tool to provide a central place to store logs received from users.
+     * Requires authentication; stores under the authenticated user's email.
      * @param Request $request
      */
     public function uploadLog(Request $request)
     {
+        $user = \Auth::user();
+        if (!$user) {
+            return response('Unauthorized', 401);
+        }
+
         $this->validate($request, [
-            'user_email' => 'required|email',
-            'log' => 'required',
-            'source' => 'required',
+            'log' => 'required|file|max:10240',
+            'source' => 'required|string|max:255',
         ]);
-        $path = $request->file('log')->store('user_logs/' . $request->input('user_email'));
+
+        $path = $request->file('log')->store('user_logs/' . $user->email);
         return "OK";
     }
 
@@ -746,25 +757,21 @@ class UserController extends Controller
                 $activation->save();
                 //Log::debug('Activation Exists.  Saved');
             } else {
-                $activation = AppUserActivation::withTrashed()->orderBy("last_sync_time", "DESC")->first();
-                if(!$activation) {
-                    $activation = new AppUserActivation;
-                    $activation->updated_at = Carbon::now()->timestamp;
-                    $activation->last_sync_time = Carbon::now();
-                    $activation->app_version = $hasAppVersion ? $request->input('app_version') : 'none';
-                    $activation->user_id = $user->id;
-                    $activation->device_id = $request->input('device_id');
-                    $activation->identifier = $request->input('identifier');
-                    $activation->ip_address = $request->ip();
-                    $activation->platform_name = $os;
-                    if ($token) {
-                        $activation->token_id = $token->id;
-                    }
-                    $activation->bypass_used = 0;
-                    $activation->save();
-                } else {
-                    $activation->restore();
+                // Never restore an unrelated activation; always create for this user.
+                $activation = new AppUserActivation;
+                $activation->updated_at = Carbon::now()->timestamp;
+                $activation->last_sync_time = Carbon::now();
+                $activation->app_version = $hasAppVersion ? $request->input('app_version') : 'none';
+                $activation->user_id = $user->id;
+                $activation->device_id = $request->input('device_id');
+                $activation->identifier = $request->input('identifier');
+                $activation->ip_address = $request->ip();
+                $activation->platform_name = $os;
+                if ($token) {
+                    $activation->token_id = $token->id;
                 }
+                $activation->bypass_used = 0;
+                $activation->save();
             }
             return $activation;
         }

--- a/CloudVeilManager/app/Http/Helpers/helpers.php
+++ b/CloudVeilManager/app/Http/Helpers/helpers.php
@@ -2,11 +2,38 @@
 
 use \Illuminate\Support\HtmlString;
 
+/**
+ * Return a safe same-origin relative redirect path, or null if unsafe.
+ * Rejects absolute URLs, protocol-relative URLs, and backslash tricks.
+ */
+function safe_redirect_path($redirect)
+{
+	if ($redirect === null || $redirect === '') {
+		return null;
+	}
+
+	if (!is_string($redirect)) {
+		return null;
+	}
+
+	// Only allow relative paths that start with a single slash.
+	if (!str_starts_with($redirect, '/') || str_starts_with($redirect, '//')) {
+		return null;
+	}
+
+	// Block control characters and backslashes (e.g. /\evil.com).
+	if (preg_match('/[\x00-\x1f\\\\\s]/', $redirect)) {
+		return null;
+	}
+
+	return $redirect;
+}
+
 function __redirect_value() {
 	if(isset($_GET['redirect'])) {
-		return $_GET['redirect'];
+		return safe_redirect_path($_GET['redirect']);
 	} else if(isset($_POST['redirect'])) {
-		return $_POST['redirect'];
+		return safe_redirect_path($_POST['redirect']);
 	} else {
 		return null;
 	}
@@ -16,7 +43,7 @@ function redirect_field() {
 	$redirect = __redirect_value();
 
 	if($redirect != null) {
-		return new HtmlString('<input type="hidden" name="redirect" value="'.$redirect.'">');
+		return new HtmlString('<input type="hidden" name="redirect" value="'.e($redirect).'">');
 	} else {
 		return new HtmlString("");
 	}

--- a/CloudVeilManager/app/Models/FilterRulesManager.php
+++ b/CloudVeilManager/app/Models/FilterRulesManager.php
@@ -31,6 +31,10 @@ class FilterRulesManager
 
     public function getFilename($listNamespace, $listCategory, $filename, $separatorChar = '.')
     {
+        $listNamespace = $this->sanitizeRulesetComponent($listNamespace);
+        $listCategory = $this->sanitizeRulesetComponent($listCategory);
+        $filename = $this->sanitizeRulesetComponent($filename);
+
         return $separatorChar . $listNamespace .
             $separatorChar . $listCategory .
             $separatorChar . $filename;
@@ -43,6 +47,7 @@ class FilterRulesManager
 
     public function getRulesetPath($namespace, $category, $type)
     {
+        $category = $this->sanitizeRulesetComponent($category);
         $filename = $this->getFilename($namespace, $category, "$type.txt");
 
         $storageDir = resource_path() . DIRECTORY_SEPARATOR . "rules" . DIRECTORY_SEPARATOR . $this->getDirForRuleset($category);
@@ -52,8 +57,28 @@ class FilterRulesManager
         return $storageDir . $filename;
     }
 
+    /**
+     * Strip path separators and parent-directory sequences from ruleset path components.
+     */
+    private function sanitizeRulesetComponent($value): string
+    {
+        $value = str_replace(["\0", '/', '\\'], '', (string) $value);
+        while (str_contains($value, '..')) {
+            $value = str_replace('..', '', $value);
+        }
+        if ($value === '.' || $value === '') {
+            return '_';
+        }
+        return $value;
+    }
+
     private function getDirForRuleset(string $category): string
     {
+        $category = $this->sanitizeRulesetComponent($category);
+        if (strlen($category) < 2) {
+            $category = str_pad($category, 2, '_');
+        }
+
         return $category[0] . DIRECTORY_SEPARATOR . $category[1] . DIRECTORY_SEPARATOR;
     }
 

--- a/CloudVeilManager/app/Providers/Socialite/CloudVeilProvider.php
+++ b/CloudVeilManager/app/Providers/Socialite/CloudVeilProvider.php
@@ -46,7 +46,13 @@ class CloudVeilProvider extends AbstractProvider implements ProviderInterface
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            'https://www.cloudveil.org/oauth/me?access_token=' . $token
+            'https://www.cloudveil.org/oauth/me',
+            [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'Authorization' => 'Bearer ' . $token,
+                ],
+            ]
         );
 
         return json_decode($response->getBody()->getContents(), true);

--- a/CloudVeilManager/routes/api.php
+++ b/CloudVeilManager/routes/api.php
@@ -108,7 +108,7 @@ Route::namespace("App\Http\Controllers")->group(function () {
         Route::put('activations/{id}', 'AppUserActivationController@update');
     });
 
-    Route::post('activations/version', 'AppUserActivationController@updateVersion');
+    Route::middleware(['check.device_id'])->post('activations/version', 'AppUserActivationController@updateVersion');
 
     Route::group(['prefix' => 'business', 'middleware' => ['db.live', 'web', 'role:admin|business-owner']], function () {
         Route::get('deactivations', 'BusinessController@getDeactivationRequests');
@@ -235,7 +235,7 @@ Route::namespace("App\Http\Controllers")->group(function () {
     Route::middleware(['check.device_id'])->post('/v2/user/activation/email', 'EmailActivationLinkController@activateOverEmail');
     Route::middleware(['check.device_id'])->post('/v2/user/activation/otp', 'EmailActivationLinkController@send2FACode');
     Route::middleware(['check.device_id'])->put('/v2/user/activation/otp', 'EmailActivationLinkController@activate2FA');
-    Route::middleware(['check.device_id'])->post('/v2/user/retrievetoken', 'UserController@retrieveUserToken');
+    Route::middleware(['auth.basic.once', 'role:admin|user|business-owner', 'check.device_id'])->post('/v2/user/retrievetoken', 'UserController@retrieveUserToken');
 
     /**
      * Management section of the API.  This is used for working with users from external sources and relies upon basic auth.
@@ -259,12 +259,9 @@ Route::namespace("App\Http\Controllers")->group(function () {
         Route::get('/activation', 'AppUserActivationController@index');
         Route::get('/activation/status/{identify}', 'AppUserActivationController@status');
         Route::post('/deactivation/{id}', 'DeactivationRequestController@update');
-        Route::get('/deactivation/{id}', 'DeactivationRequestController@update');
         Route::post('activations/delete/{id}', 'AppUserActivationController@destroy');
         Route::post('activations/block/{id}', 'AppUserActivationController@block');
     });
 
-    Route::group(['middleware' => []], function () {
-        Route::post('upload/log', 'UserController@uploadLog');
-    });
+    Route::middleware(['auth.basic.once', 'role:admin|user|business-owner'])->post('upload/log', 'UserController@uploadLog');
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the CloudVeilManager findings from the FilterManager security review. CitadelManager is intentionally out of scope for this PR.

### Critical / high fixes

| Issue | Change |
|-------|--------|
| Unauthenticated `retrievetoken` token minting | Require `auth.basic.once` + role (same as `gettoken`); only issue tokens for activations owned by the authenticated user |
| Open redirect + reflected XSS on login | Allow only same-origin relative paths via `safe_redirect_path()`; HTML-escape `redirect_field()` |
| Path traversal on release downloads | `basename` + `realpath` confinement under `public/releases/` |
| Unauthenticated log upload | Require basic auth; store under authenticated user’s email; validate upload size |
| Unauthenticated `activations/version` | Add `updateVersion` implementation; require `check.device_id` and matching `acid`/`identifier`/`device_id` |
| Wrong activation restore | Stop restoring arbitrary soft-deleted activations in `getAndTouchActivation`; always create for current user |
| Ruleset path traversal | Sanitize namespace/category path components in `FilterRulesManager` |
| SSO silent account linking | Refuse linking password-backed accounts to SSO without verification |
| CSRF-friendly deactivation GET | Remove `GET /api/manage/deactivation/{id}` state-changing route |
| OAuth token in URL | Send Bearer header instead of `access_token` query param |
| Weak password policy | Raise minimum new password length from 4 → 8 |

### Compatibility notes

- Clients calling `POST /api/v2/user/retrievetoken` must now send HTTP basic credentials (same as `gettoken`).
- Clients calling `POST /api/upload/log` must authenticate; `user_email` is no longer accepted from the client.
- Clients calling `POST /api/activations/version` must send `identifier` + `device_id` (via `check.device_id`) matching `acid`.
- SSO `/oauth/me` must accept `Authorization: Bearer` (query-string token removed).

### Out of scope

CitadelManager-only issues (e.g. token `user_id` reassignment already absent in CloudVeilManager, DataTables `orderBy` SQLi, admin TS `innerHTML` XSS) are not included here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5198a369-4521-4c98-8cb6-97f289c94169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5198a369-4521-4c98-8cb6-97f289c94169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

